### PR TITLE
Removed unnecessary working directory paths

### DIFF
--- a/.github/workflows/treetracker-dev-cdn-deploy.yml
+++ b/.github/workflows/treetracker-dev-cdn-deploy.yml
@@ -27,14 +27,11 @@ jobs:
         node-version: '14.x'
     - name: npm clean install
       run: npm ci
-      working-directory: ${{ env.project-directory }}
     - name: run ESLint
       run: npm run lint
-      working-directory: ${{ env.project-directory }}
     # define the endpoints for DEV in github secrets
     - name: build frontend project
       run: ${{ secrets.DEV_APP_ENDPOINTS }} npm run build
-      working-directory: ${{ env.project-directory }}
     - uses: actions/upload-artifact@v2
       if: github.event_name == 'push' && github.repository == "Greenstand/${{ github.event.repository.name }}"
       with:
@@ -42,7 +39,6 @@ jobs:
         path: build
     - name: run React tests
       run: npm test
-      working-directory: ${{ env.project-directory }}
   release:
     name: Release semantic version
     needs: frontend


### PR DESCRIPTION
There was no need for `working-directory` for those npm commands because it was already defined at [Line 12](https://github.com/Greenstand/treetracker-wallet-web/blob/main/.github/workflows/treetracker-dev-cdn-deploy.yml#L12)

Fixes Greenstand/treetracker-infrastructure#67